### PR TITLE
Fix execution of fixpack in projects with spaces in the CWD

### DIFF
--- a/tasks/nice_package.js
+++ b/tasks/nice_package.js
@@ -94,10 +94,10 @@ function initValidators(grunt) {
 }
 
 function sortPackageProperties(grunt, done, blankLine, valid) {
-  var fixpack = join(__dirname, '../node_modules/fixpack');
+  var fixpack = join(__dirname, '../node_modules/.bin/fixpack');
   var exec = require('child_process').exec;
 
-  exec('node "' + fixpack + '"', function (error, stdout, stderr) {
+  exec('"' + fixpack + '"', function (error, stdout, stderr) {
     if (error) {
       grunt.log.error(error);
       done(false);


### PR DESCRIPTION
Hi there,

Fixpack couldn't get executed in projects with spaces in the path, I fixed it by surrounding the path with double quotes.

I added an additional optimization: instead of executing `node <...>/node_modules/fixpack/fixpack` it's better to execute the bin file in node_modules/.bin directly. Obviously ATM this is the same thing since .bin/fixpack file is a symlink, but the advantage is that should fixpack change their directory structure (and dump the fixpack file in a lib dir for instance) then you won't have to update your code, otherwise you would.

However if you don't like the optimization, just cherry-pick the first commit to fix the execution in paths with spaces.
