### PR TITLE
updating package-json-validator dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "check-more-types": "2.3.0",
     "fixpack": "2.2.0",
     "glob": "6.0.1",
-    "package-json-validator": "git+https://github.com/hemanth/package.json-validator.git#0f3d9ca5576cc1dc2e47b2321a6bbf2febb3ae48"
+    "package-json-validator": "0.6.1"
   },
   "devDependencies": {
     "git-issues": "1.2.0",


### PR DESCRIPTION
This PR changes the package-json-validator to use a npm dependency, rather than a direct github dependency that appears to no longer exist.